### PR TITLE
Correct misspelling of architectures library.properties field name

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -6,5 +6,5 @@ sentence=A library for quadrature encoder utilizing enableInterrupt.h.
 paragraph=This library make it easier to use quadrature encoder. The library counts the encoder pulses in the background and user just have to call a method function to get encoder count. Note: enableInterrupt library is needed for this library to work. 
 category=Sensors
 url=https://github.com/Saeterncj/QuadratureEncoder
-architecture=avr
+architectures=avr
 includes=QuadratureEncoder.h


### PR DESCRIPTION
The correct spelling of the field name is architectures, not architecture.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#libraryproperties-file-format