### PR TITLE
Allow EnableInterrupt to be added more than once in a project

### DIFF
--- a/QuadratureEncoder.cpp
+++ b/QuadratureEncoder.cpp
@@ -1,3 +1,4 @@
+#define LIBCALL_ENABLEINTERRUPT
 #include <EnableInterrupt.h>
 #include "QuadratureEncoder.h"
 

--- a/examples/SimpleEncoderExample/SimpleEncoderExample.ino
+++ b/examples/SimpleEncoderExample/SimpleEncoderExample.ino
@@ -1,6 +1,5 @@
-
+#include <EnableInterrupt.h> // be sure to install and include EnableInterrupt in the sketch
 #include <QuadratureEncoder.h>
-// must also have enableInterrupt.h library
 
 // Use any 2 pins for interrupt, this utilizes EnableInterrupt Library. 
 // Even analog pins can be used. A0 = 14,A1=15,..etc for arduino nano/uno


### PR DESCRIPTION
I was having linker errors when using QuadratureEncoder and EnableInterrupt in the same sketch, reading the EnableInterrupt [docs](https://github.com/GreyGnome/EnableInterrupt/wiki/Usage#Calling_the_Library_from_Other_Libraries), i noticed that the problems was actually caused by QuadratureEncoder. This fixes the issue.